### PR TITLE
Sort licenses alphabetically by target name

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ import LicensesViewController
 // ...
 
 let licensesController = LicensesViewController()
-licensesController.loadPlist(NSBundle.mainBundle(), resourceName: "Credits")
+licensesController.loadPlist(Bundle.main, resourceName: "Credits")
 
 // ...
 ```

--- a/credits.py
+++ b/credits.py
@@ -93,6 +93,8 @@ def plist_from_dir(directory, excludes):
     for plist_path in plist_paths:
         license_dict = plist_from_file(plist_path)
         plist['PreferenceSpecifiers'].append(license_dict)
+
+    plist['PreferenceSpecifiers'] = sorted(plist['PreferenceSpecifiers'], key=lambda x: x['Title'])
     return plist
 
 


### PR DESCRIPTION
This patch sorts the licenses alphabetically by target name.
This also updates the example code in the README to Swift 4.0 syntax.