### PR TITLE
Allow comma-separated list of directories as input for --source

### DIFF
--- a/credits.py
+++ b/credits.py
@@ -43,7 +43,8 @@ class MultipleOption(Option):
 
 def main(_):
     def list_callback(option, _, value, option_parser):
-        setattr(option_parser.values, option.dest, [item.strip() for item in value.split(',')])
+        values = [item.strip() for item in value.split(',')]
+        setattr(option_parser.values, option.dest, values)
 
     parser = OptionParser(option_class=MultipleOption,
                           usage='usage: %prog -s source_path -o output_plist -e [exclude_paths]',
@@ -53,7 +54,8 @@ def main(_):
                       action="callback", type="string",
                       dest='input_path',
                       metavar='source_path',
-                      help='comma separated list of directories to recursively search for licenses',
+                      help='comma separated list of directories to \
+                          recursively search for licenses',
                       callback=list_callback)
     parser.add_option('-o', '--output-plist',
                       type="string",
@@ -98,13 +100,13 @@ def main(_):
 
 def plist_from_dirs(directories, excludes, include_tests):
     """
-    Recursively searches each directory in 'directories' and generate plists objects 
-    from any LICENSE files found.
+    Recursively searches each directory in 'directories' and
+    generates plist objects from any LICENSE files found.
     """
     plist = {'PreferenceSpecifiers': [], 'StringsTable': 'Acknowledgements'}
     for directory in directories:
         license_paths = license_paths_from_dir(directory)
-        plist_paths = (plist_path for plist_path in license_paths if not exclude_path(plist_path, excludes, include_tests))
+        plist_paths = [plist_path for plist_path in license_paths if not exclude_path(plist_path, excludes, include_tests)]
         for plist_path in plist_paths:
             license_dict = plist_from_file(plist_path)
             plist['PreferenceSpecifiers'].append(license_dict)

--- a/credits.py
+++ b/credits.py
@@ -21,7 +21,7 @@ from optparse import OptionParser
 from optparse import Option, OptionValueError
 from copy import deepcopy
 
-VERSION = '0.4.0'
+VERSION = '0.5.0'
 PROG = os.path.basename(os.path.splitext(__file__)[0])
 DESCRIPTION = """Generate a `Settings.bundle` friendly plist file from all
  'LICENSE.*' files in a given directory. Inspired by JosephH and Sean's
@@ -42,18 +42,19 @@ class MultipleOption(Option):
 
 
 def main(_):
-    def exclude_callback(option, _, value, option_parser):
-        setattr(option_parser.values, option.dest, value.split(','))
+    def list_callback(option, _, value, option_parser):
+        setattr(option_parser.values, option.dest, [item.strip() for item in value.split(',')])
 
     parser = OptionParser(option_class=MultipleOption,
                           usage='usage: %prog -s source_path -o output_plist -e [exclude_paths]',
                           version='%s %s' % (PROG, VERSION),
                           description=DESCRIPTION)
     parser.add_option('-s', '--source',
-                      type="string",
+                      action="callback", type="string",
                       dest='input_path',
                       metavar='source_path',
-                      help='source directory to search for licenses')
+                      help='comma separated list of directories to recursively search for licenses',
+                      callback=list_callback)
     parser.add_option('-o', '--output-plist',
                       type="string",
                       dest='output_file',
@@ -64,7 +65,7 @@ def main(_):
                       dest='excludes',
                       metavar='path1, ...',
                       help='comma separated list of paths to be excluded',
-                      callback=exclude_callback)
+                      callback=list_callback)
     parser.add_option('-t', '--test',
                       action="store_true",
                       dest='include_tests',
@@ -76,15 +77,17 @@ def main(_):
 
     options, args = parser.parse_args()
 
-    if not os.path.isdir(options.input_path):
-        print("Error: Invalid source path: %s" % options.input_path)
-        sys.exit(2)
+    print options.input_path
+    for path in options.input_path:
+        if(not os.path.isdir(path)):
+            print "Error: Source path does not exist: %s" % path
+            sys.exit(2)
 
     if not options.output_file.endswith('.plist'):
         print("Error: Outputfile must end in .plist")
         sys.exit(2)
 
-    plist = plist_from_dir(
+    plist = plist_from_dirs(
         options.input_path,
         options.excludes,
         options.include_tests
@@ -93,22 +96,24 @@ def main(_):
     return 0
 
 
-def plist_from_dir(directory, excludes, include_tests):
+def plist_from_dirs(directories, excludes, include_tests):
     """
-    Recursively search 'dir' to generates plist objects from LICENSE files.
+    Recursively searches each directory in 'directories' and generate plists objects 
+    from any LICENSE files found.
     """
     plist = {'PreferenceSpecifiers': [], 'StringsTable': 'Acknowledgements'}
-    license_paths = license_paths_form_dir(directory)
-    plist_paths = (plist_path for plist_path in license_paths if not exclude_path(plist_path, excludes, include_tests))
-    for plist_path in plist_paths:
-        license_dict = plist_from_file(plist_path)
-        plist['PreferenceSpecifiers'].append(license_dict)
+    for directory in directories:
+        license_paths = license_paths_from_dir(directory)
+        plist_paths = (plist_path for plist_path in license_paths if not exclude_path(plist_path, excludes, include_tests))
+        for plist_path in plist_paths:
+            license_dict = plist_from_file(plist_path)
+            plist['PreferenceSpecifiers'].append(license_dict)
 
     plist['PreferenceSpecifiers'] = sorted(plist['PreferenceSpecifiers'], key=lambda x: x['Title'])
     return plist
 
 
-def license_paths_form_dir(directory):
+def license_paths_from_dir(directory):
     return_dict = []
     os.chdir(sys.path[0])
     for dir_path, _, file_names in os.walk(directory):


### PR DESCRIPTION
This PR makes it so that the `--source` flag can take a comma-separated list of directories as input. This way, you can recursively scan multiple directories, such as your Pods directory and your Swift Package Manager directory.

I also do a tiny bit of housekeeping. Each path in a comma-separated list now gets stripped so that a space after a comma doesn't cause the script to fail to find the path.