### PR TITLE
Use pre-release notation for better cocoapod / spm support

### DIFF
--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/LicensesViewController.podspec
+++ b/LicensesViewController.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "LicensesViewController"
-  s.version          = "0.11.0+volvo3"
+  s.version          = "0.12.0-alpha.1.volvo"
   s.summary          = "Give credit where credit is due."
   s.description      = <<-DESC
                         Recursively finds all LICENSE.* files in a given directory and generates that can be displayed via Settings.bundle or the provided view controller.

--- a/LicensesViewController.podspec
+++ b/LicensesViewController.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "LicensesViewController"
-  s.version          = "0.11.0"
+  s.version          = "0.11.0+volvo1"
   s.summary          = "Give credit where credit is due."
   s.description      = <<-DESC
                         Recursively finds all LICENSE.* files in a given directory and generates that can be displayed via Settings.bundle or the provided view controller.

--- a/LicensesViewController.podspec
+++ b/LicensesViewController.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
   }
   s.source           = { :git => "https://github.com/volvogroup-mobility/LicenseGenerator-iOS.git", :tag => s.version.to_s }
 
-  s.ios.deployment_target = '8.0'
+  s.ios.deployment_target = '11.0'
   s.swift_versions = ['4.2', '5.0', '5.1', '5.2']
   s.requires_arc = true
 

--- a/LicensesViewController.podspec
+++ b/LicensesViewController.podspec
@@ -6,11 +6,14 @@ Pod::Spec.new do |s|
                         Recursively finds all LICENSE.* files in a given directory and generates that can be displayed via Settings.bundle or the provided view controller.
                        DESC
 
-  s.homepage         = "https://github.com/carloe/LicenseGenerator-iOS"
-  s.screenshot       = "https://github.com/carloe/LicenseGenerator-iOS/raw/master/screenshot.png"
+  s.homepage         = "https://github.com/volvogroup-mobility/LicenseGenerator-iOS"
+  s.screenshot       = "https://github.com/volvogroup-mobility/LicenseGenerator-iOS/raw/main/screenshot.png"
   s.license          = 'MIT'
-  s.author           = { "Carlo Eugster" => "carlo@relaun.ch" }
-  s.source           = { :git => "https://github.com/carloe/LicenseGenerator-iOS.git", :tag => s.version.to_s }
+  s.author           = { 
+    "Carlo Eugster" => "carlo@relaun.ch",
+    'Timothy G. Rundle' => 'timothy.rundle@volvo.com'
+  }
+  s.source           = { :git => "https://github.com/volvogroup-mobility/LicenseGenerator-iOS.git", :tag => s.version.to_s }
 
   s.ios.deployment_target = '8.0'
   s.tvos.deployment_target = '9.0'

--- a/LicensesViewController.podspec
+++ b/LicensesViewController.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "LicensesViewController"
-  s.version          = "0.11.0+volvo2"
+  s.version          = "0.11.0+volvo3"
   s.summary          = "Give credit where credit is due."
   s.description      = <<-DESC
                         Recursively finds all LICENSE.* files in a given directory and generates that can be displayed via Settings.bundle or the provided view controller.

--- a/LicensesViewController.podspec
+++ b/LicensesViewController.podspec
@@ -16,7 +16,6 @@ Pod::Spec.new do |s|
   s.source           = { :git => "https://github.com/volvogroup-mobility/LicenseGenerator-iOS.git", :tag => s.version.to_s }
 
   s.ios.deployment_target = '8.0'
-  s.tvos.deployment_target = '9.0'
   s.swift_versions = ['4.2', '5.0', '5.1', '5.2']
   s.requires_arc = true
 

--- a/LicensesViewController.podspec
+++ b/LicensesViewController.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "LicensesViewController"
-  s.version          = "0.11.0+volvo1"
+  s.version          = "0.11.0+volvo2"
   s.summary          = "Give credit where credit is due."
   s.description      = <<-DESC
                         Recursively finds all LICENSE.* files in a given directory and generates that can be displayed via Settings.bundle or the provided view controller.

--- a/LicensesViewController.xcodeproj/project.pbxproj
+++ b/LicensesViewController.xcodeproj/project.pbxproj
@@ -433,6 +433,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = LicensesViewController/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.relaunch.LicensesViewController;
 				PRODUCT_NAME = LicensesViewController;
@@ -454,6 +455,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = LicensesViewController/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.relaunch.LicensesViewController;
 				PRODUCT_NAME = LicensesViewController;
@@ -467,6 +469,7 @@
 			buildSettings = {
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = Tests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.relaunch.LicensesViewControllerTests;
 				PRODUCT_NAME = LicensesViewControllerTests;
@@ -479,6 +482,7 @@
 			buildSettings = {
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = Tests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.relaunch.LicensesViewControllerTests;
 				PRODUCT_NAME = LicensesViewControllerTests;

--- a/LicensesViewController/LicensesViewController.swift
+++ b/LicensesViewController/LicensesViewController.swift
@@ -130,6 +130,7 @@ class LicenseCell: UITableViewCell {
         titleLabel.textColor = UIColor.black
     }
     titleLabel.translatesAutoresizingMaskIntoConstraints = false
+    titleLabel.semanticContentAttribute = .forceLeftToRight
     titleLabel.font = UIFont.preferredFont(forTextStyle: UIFont.TextStyle.headline)
     titleLabel.lineBreakMode = .byTruncatingTail
     titleLabel.numberOfLines = 1
@@ -141,6 +142,7 @@ class LicenseCell: UITableViewCell {
         bodyLabel.textColor = UIColor.darkGray
     }
     bodyLabel.translatesAutoresizingMaskIntoConstraints = false
+    bodyLabel.semanticContentAttribute = .forceLeftToRight
     bodyLabel.font = UIFont.preferredFont(forTextStyle: UIFont.TextStyle.footnote)
     bodyLabel.lineBreakMode = .byWordWrapping
     bodyLabel.numberOfLines = 0

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,20 @@
+// swift-tools-version: 5.5
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "LicensesViewController",
+    defaultLocalization: "en",
+    platforms: [.iOS(.v11)],
+    products: [
+        .library(name: "LicensesViewController", targets: ["LicensesViewController"])
+    ],
+    dependencies: [],
+    targets: [
+        .target(name: "LicensesViewController",
+                dependencies: [],
+                path: "LicensesViewController",
+                sources: ["LicensesViewController.swift", "Extensions"]
+        )
+    ])

--- a/README.md
+++ b/README.md
@@ -31,7 +31,11 @@ You can optionally tell the generator to ignore certain paths. To do so use the 
 ## View Controller
 If your app doesn't use a `Settings.bundle` you can use the provided view controller to show the licenses.
 
-#### Installation
+### Installation
+
+Grab [credits.py](https://raw.githubusercontent.com/volvogroup-mobility/LicenseGenerator-iOS/main/credits.py) from this repo and add it to your project.
+
+#### Cocoapods
 
 Add LicensesViewController to your `Podfile`:
 
@@ -40,7 +44,7 @@ source 'https://github.com/CocoaPods/Specs.git'
 platform :ios, '8.0'
 use_frameworks!
 
-pod 'LicensesViewController', '~> 0.10.0'
+pod 'LicensesViewController', :source => 'https://github.com/volvogroup-mobility/Podspecs.git' 
 ```
 
 Then tell Pod to install it:
@@ -49,9 +53,29 @@ Then tell Pod to install it:
 $ pod install
 ```
 
-Grab `credits.py` from this repo and add it to your project.
+#### Swift Package Manager
 
-#### Usage
+Add the following to Package.swift
+
+``` swift
+let package = Package(
+    ...
+    dependencies: [
+    .package(name: "LicensesViewController", url: "https://github.com/volvogroup-mobility/LicenseGenerator-iOS", from: "0.11.0+volvo2")
+    ],
+    targets: [
+    .target(
+        ...
+        dependencies: [
+        .product(name: "LicensesViewController", package: "LicensesViewController")
+        ],
+        ...
+    ),
+    ]
+)
+```
+
+### Usage
 
 Add the build script as described above and make sure the resulting plist is included in the app target.
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Add the following to Package.swift
 let package = Package(
     ...
     dependencies: [
-    .package(name: "LicensesViewController", url: "https://github.com/volvogroup-mobility/LicenseGenerator-iOS", from: "0.11.0+volvo3")
+    .package(name: "LicensesViewController", url: "https://github.com/volvogroup-mobility/LicenseGenerator-iOS", from: "0.12.0-alpha.1.volvo")
     ],
     targets: [
     .target(

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Add the following to Package.swift
 let package = Package(
     ...
     dependencies: [
-    .package(name: "LicensesViewController", url: "https://github.com/volvogroup-mobility/LicenseGenerator-iOS", from: "0.11.0+volvo2")
+    .package(name: "LicensesViewController", url: "https://github.com/volvogroup-mobility/LicenseGenerator-iOS", from: "0.11.0+volvo3")
     ],
     targets: [
     .target(

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ open LicensesViewControllerExample.xcworkspace
 ```
 
 #### Requirements
-* iOS `8.0`
+* iOS `11.0`
 * Swift `4.2`, `5.0`, `5.1`, `5.2`
 
 If you depend on Python `2.x` use `'~> 0.9.0'` in your Podfile. 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,6 @@ open LicensesViewControllerExample.xcworkspace
 
 #### Requirements
 * iOS `8.0`
-* tvOS `9.0`
 * Swift `4.2`, `5.0`, `5.1`, `5.2`
 
 If you depend on Python `2.x` use `'~> 0.9.0'` in your Podfile. 


### PR DESCRIPTION
Neither Cocoapods nor SPM take build info into consideration when determining updates. As a result a number of edge case issues have arisen. This PRs changes the versioning standard from adding build info to use pre-release info